### PR TITLE
Fryingpan

### DIFF
--- a/Demo/GL/GLExcess/mmakefile.src
+++ b/Demo/GL/GLExcess/mmakefile.src
@@ -52,7 +52,7 @@ else
 endif
 
 $(GLEXCESS_SOURCES) :
-%compile_q cmd=$(CXX_CC) opt=$(CXX_FLAGS) from=$(SRCDIR)/$(CURDIR)/$@.cpp to="$(addsuffix .o,$(addprefix $(GENDIR)/$(CURDIR)/,$(notdir $@)))"
+%compile_q cmd="$(CXX_CC) $(TARGET_SYSROOT)" opt=$(CXX_FLAGS) from=$(SRCDIR)/$(CURDIR)/$@.cpp to="$(addsuffix .o,$(addprefix $(GENDIR)/$(CURDIR)/,$(notdir $@)))"
 
 #MM
 demos-gl-glexcess-cpp : demos-gl-glexcess-cpp-directories-setup $(GLEXCESS_SOURCES)
@@ -65,7 +65,7 @@ USER_LDFLAGS := -L$(AROS_LIB) -static-libstdc++
 
 #MM
 demos-gl-glexcess :
-%link_q cmd=$(TARGET_CXX) from="$(addsuffix .o,$(addprefix $(GENDIR)/$(CURDIR)/,$(notdir $(GLEXCESS_SOURCES))))" to=$(AROS_CONTRIB)/Demos/GL/GLExcess/GLExcess libs="-lglut -lGL -lGLU"
+%link_q cmd="$(TARGET_CXX) $(TARGET_SYSROOT)" from="$(addsuffix .o,$(addprefix $(GENDIR)/$(CURDIR)/,$(notdir $(GLEXCESS_SOURCES))))" to=$(AROS_CONTRIB)/Demos/GL/GLExcess/GLExcess libs="-lglut -lGL -lGLU"
 
 #MM
 demos-gl-glexcess-copyfiles :

--- a/FryingPan/DTLib/rMP3Audio.cpp
+++ b/FryingPan/DTLib/rMP3Audio.cpp
@@ -499,7 +499,7 @@ bool                  rMP3Audio::readData(const IOptItem* item, void* buff, int 
    return true;
 }
    
-uint                  rMP3Audio::access(void* , MPEGA_ACCESS *acc)
+uintptr_t                  rMP3Audio::access(void* , MPEGA_ACCESS *acc)
 {
    register uint32 d;
 
@@ -513,7 +513,7 @@ uint                  rMP3Audio::access(void* , MPEGA_ACCESS *acc)
          DOS->Seek(handle, stream_start, OFFSET_BEGINNING);
          current_location = 0;
          _D(Lvl_Info, "%s: MPEGA_OPEN - Opening virtual stream. Current location: %ld", (uint)__PRETTY_FUNCTION__, current_location);
-         return (uint)this;
+         return (uintptr_t)this;
 
       case MPEGA_BSFUNC_CLOSE:
          /*

--- a/FryingPan/DTLib/rMP3Audio.h
+++ b/FryingPan/DTLib/rMP3Audio.h
@@ -63,7 +63,7 @@ protected:
    static bool                   checkMP3(BPTR fh, EDtError &rc);
    static long                   verifyFrame(unsigned char* pFrame, EDtError &rc);
 
-   uint                          access(void* handle, MPEGA_ACCESS *acc);
+   uintptr_t                     access(void* handle, MPEGA_ACCESS *acc);
 public:
    static IFileReader           *openRead(const char* sFile, EDtError &rc);
    static bool                   checkFile(const char* sFileName, EDtError &rc);

--- a/FryingPan/FP/Application.cpp
+++ b/FryingPan/FP/Application.cpp
@@ -50,7 +50,7 @@ Application::Application()
       }
       Interface = 0;
       _d(Lvl_Info, "%s: Freeing module...", (IPTR)__PRETTY_FUNCTION__);
-      Module->FreeInstance();
+    //   Module->FreeInstance();
    }
    else
    {

--- a/FryingPan/FP/Engine/Jobs/JobISORemItem.cpp
+++ b/FryingPan/FP/Engine/Jobs/JobISORemItem.cpp
@@ -27,7 +27,7 @@ JobISORemItem::JobISORemItem(unsigned long drv, IBrowser* b, ClElement *el) :
    elem = el;
    dir = b->getCurrDir();
 
-   action.FormatStr("Removing %s", ARRAY((uint)elem->getNormalName()));
+   action.FormatStr("Removing %s", ARRAY((uintptr_t)elem->getNormalName()));
 }
 
 JobISORemItem::~JobISORemItem()

--- a/FryingPan/FP/Engine/Jobs/JobLayout.cpp
+++ b/FryingPan/FP/Engine/Jobs/JobLayout.cpp
@@ -136,7 +136,7 @@ void JobLayout::analyse(EOpticalError ret)
                   ((fsize * 100) >> 10) % 100,
                   (IPTR)suff.Data(),
                   scurr,
-                  ssize,
+                  ssize
                   ));
          numblocks = scurr;
       }

--- a/FryingPan/FP/Engine/Jobs/JobMediumAction.cpp
+++ b/FryingPan/FP/Engine/Jobs/JobMediumAction.cpp
@@ -134,7 +134,7 @@ void JobMediumAction::closeTracks()
 {
    const IOptItem *dsc, *ses, *trk;
 
-   pOptical->OptDoMethodA(ARRAY(DRV_GetAttrs, Drive, DRA_Disc_Contents, (uint)&dsc, 0));
+   pOptical->OptDoMethodA(ARRAY(DRV_GetAttrs, Drive, DRA_Disc_Contents, (uintptr_t)&dsc, 0));
 
    if (dsc)
    {

--- a/FryingPan/FP/Engine/Jobs/JobUpload.cpp
+++ b/FryingPan/FP/Engine/Jobs/JobUpload.cpp
@@ -138,7 +138,7 @@ void JobUpload::execute()
    }
 }
 
-uint JobUpload::onData(void* mem, int sectors)
+uintptr_t JobUpload::onData(void* mem, int sectors)
 {
    EOpticalError ret = ODE_OK;
 

--- a/FryingPan/FP/Engine/Jobs/JobUpload.h
+++ b/FryingPan/FP/Engine/Jobs/JobUpload.h
@@ -46,7 +46,7 @@ protected:
    HookT<JobUpload, void*, int>  hHkData;
 
 protected:
-   virtual uint          onData(void* mem, int sectors);
+   virtual uintptr_t       onData(void* mem, int sectors);
 public:
                            JobUpload(unsigned long drive, VectorT<ITrack*> &tracks, bool masterize, bool closedisc);
    virtual                ~JobUpload();                              

--- a/FryingPan/FP/GUI-MUI/GUI.cpp
+++ b/FryingPan/FP/GUI-MUI/GUI.cpp
@@ -548,7 +548,7 @@ IPTR GUI::doUserAction(ActionID act, IPTR)
    switch (act)
    {
       case Action_AboutMUI:
-         DoMtd((Object *)pApp, ARRAY(MUIM_Application_AboutMUI, (uint)pWin));
+         DoMtd((Object *)pApp, ARRAY(MUIM_Application_AboutMUI, (uintptr_t)pWin));
          break;
 
       case Action_MUISettings:

--- a/FryingPan/FP/GUI-MUI/GUI.cpp
+++ b/FryingPan/FP/GUI-MUI/GUI.cpp
@@ -313,7 +313,7 @@ bool GUI::start()
    Record->start();
 
    _dx(Lvl_Info, "*pop*");
-   Intuition->SetAttrsA(pWin, TAGARRAY(
+   Intuition->SetAttrsA(pWin, ARRAY(
             MUIA_Window_Open, true,
             TAG_DONE,         0));
 
@@ -356,7 +356,7 @@ void GUI::stop()
       return;
 
    _dx(Lvl_Info, "Hiding main window");
-   Intuition->SetAttrsA(pWin, TAGARRAY(
+   Intuition->SetAttrsA(pWin, ARRAY(
             MUIA_Window_Open, false,
             TAG_DONE,         0));
 
@@ -387,12 +387,12 @@ IPTR GUI::doShowHide(IPTR, IPTR)
 {
    _dx(Lvl_Info, "Switching UI");
    _dx(Lvl_Info, "Hiding main window");
-   Intuition->SetAttrsA(pWin, TAGARRAY(
+   Intuition->SetAttrsA(pWin, ARRAY(
             MUIA_Window_Open,     false,
             TAG_DONE,             0));
 
    _dx(Lvl_Info, "Rearranging elements (new state: %ld)", !bCompact);
-   Intuition->SetAttrsA(elements, TAGARRAY(
+   Intuition->SetAttrsA(elements, ARRAY(
       MUIA_ShowMe,   (unsigned)bCompact,
       TAG_DONE,      0
    ));
@@ -400,13 +400,13 @@ IPTR GUI::doShowHide(IPTR, IPTR)
    bCompact = !bCompact;
 
    _dx(Lvl_Info, "Applying new ID");
-   Intuition->SetAttrsA(pWin, TAGARRAY(
+   Intuition->SetAttrsA(pWin, ARRAY(
             MUIA_Window_ID,       bCompact ?
                MAKE_ID('M', 'I', 'N', 'I') : MAKE_ID('M', 'A', 'I', 'N'),
             TAG_DONE,             0));
 
    _dx(Lvl_Info, "Showing main window");
-   Intuition->SetAttrsA(pWin, TAGARRAY(
+   Intuition->SetAttrsA(pWin, ARRAY(
             MUIA_Window_Open,     true,
             TAG_DONE,             0));
 

--- a/FryingPan/FP/GUI-MUI/MUIDrive.cpp
+++ b/FryingPan/FP/GUI-MUI/MUIDrive.cpp
@@ -160,7 +160,7 @@ IPTR MUIDrive::getObject()
    if (popDevice == 0)
    {
       _dx(Lvl_Info, "Setting up PopDevice");
-      popDevice = new MUIPopDevice(Glb.Loc[loc_DrivePopDevice], (const char**)ARRAY((IPTR)Glb.Loc[loc_ColDevDevices].Data(), 0));
+      popDevice = new MUIPopDevice(Glb.Loc[loc_DrivePopDevice], (const char**)(APTR)ARRAY((IPTR)Glb.Loc[loc_ColDevDevices].Data(), 0));
       popDevice->setID(ID_DeviceSelect);
       popDevice->setCallbackHook(hHkButtonHook.GetHook());
    }
@@ -168,7 +168,7 @@ IPTR MUIDrive::getObject()
    if (popUnit == 0)
    {
       _dx(Lvl_Info, "Setting up PopUnit");
-      popUnit   = new MUIPopUnit(Glb, Glb.Loc[loc_DrivePopUnit], (const char**)ARRAY(
+      popUnit   = new MUIPopUnit(Glb, Glb.Loc[loc_DrivePopUnit], (const char**)(APTR)ARRAY(
                (IPTR)Glb.Loc[loc_ColUnitNumber].Data(),
                (IPTR)Glb.Loc[loc_ColUnitVendor].Data(),
                (IPTR)Glb.Loc[loc_ColUnitDrive].Data(),

--- a/FryingPan/FP/GUI-MUI/MUIPageSelect.cpp
+++ b/FryingPan/FP/GUI-MUI/MUIPageSelect.cpp
@@ -163,7 +163,7 @@ void MUIPageSelect::stop()
    return;
 }
 
-IPTR MUIPageSelect::pageSel(MUIToolBar*, uint page)
+IPTR MUIPageSelect::pageSel(MUIToolBar*, IPTR page)
 {
    return callBack(this, page);
 }

--- a/FryingPan/FP/Main.cpp
+++ b/FryingPan/FP/Main.cpp
@@ -33,9 +33,15 @@ int main()
 {
    LibrarySpool::Init();
 
-   delete new Application();
+// FIXME
+// There is some sort of problem where operator new from LibC is used
+// but operator delete is used form standard C++ library which causes
+// crashes at exit
 
-   LibrarySpool::Exit();
+//    delete
+   new Application();
+
+//    LibrarySpool::Exit();
 
    return 0;
 }

--- a/FryingPan/ISOBuilder/ISOStructures.cpp
+++ b/FryingPan/ISOBuilder/ISOStructures.cpp
@@ -117,7 +117,7 @@ void ISODate::setDate(const struct DateStamp *pDS)
    Date hDate(pDS);
    
    s.FormatStr("%04ld%02ld%02ld%02ld%02ld%02ld%02ld", ARRAY(
-         hDate.Year, 
+         (IPTR)hDate.Year,
          hDate.Month,
          hDate.Day,
          hDate.Hour,

--- a/FryingPan/Optical/Commands.h
+++ b/FryingPan/Optical/Commands.h
@@ -491,7 +491,7 @@ public:
    int32            GetSpeedDescriptor(int32 i);
    int32            GetMediaReadSupport();
    int32            GetMediaWriteSupport();
-   uint             GetCapabilities();
+   uintptr_t        GetCapabilities();
    int32            GetAudioFlags();
    int32            GetAudioVolumeLevels();
    uint16           GetCurrentWriteSpeed();
@@ -1750,7 +1750,7 @@ class cmd_GetConfiguration : public SCSICommand
    public:
       int32       IsCurrent(void)      {  return type.isCurrent();                     };
       FeatureId   GetId()              {  return (FeatureId)(int16)id;                 };
-      Feature*    Next()               {  return (Feature*)(((uint)this)+length+4);  };
+      Feature*    Next()               {  return (Feature*)(((uintptr_t)this)+length+4);  };
       int32       GetLength()          {  return length+4;                             };
       APTR        GetBody()            {  return &((uint8*)this)[4];                   };
       int32       GetBodyLength()      {  return length;                               };

--- a/FryingPan/Optical/Drive.cpp
+++ b/FryingPan/Optical/Drive.cpp
@@ -426,7 +426,7 @@ void Drive::AnalyseDrive(void)
    Cfg->onWrite();
 }
 
-uint Drive::HandleMessages(uint ACmd, uint *msg)
+uintptr_t Drive::HandleMessages(uint ACmd, uintptr_t *msg)
 {
    if (drive_status == DRT_DriveStatus_NotOpened)
       return (unsigned)ODE_NoHandler;
@@ -667,13 +667,13 @@ long Drive::LockDrive(long lLockType)
 }
 
 
-uint Drive::GetDriveAttrs(uint tag, uint attr)
+uintptr_t Drive::GetDriveAttrs(uint tag, uintptr_t attr)
 {
    if (drive_status == DRT_DriveStatus_NotOpened)
       return 0;
   
    register Disc* d = current_disc.ObtainRead(); 
-   register uint res = 0;
+   register uintptr_t res = 0;
       
    switch (tag)
    {
@@ -684,7 +684,7 @@ uint Drive::GetDriveAttrs(uint tag, uint attr)
           break;
 
       case DRA_DeviceName:                   
-          res = (uint)drive_name.Data();
+          res = (uintptr_t)drive_name.Data();
           break;
 
       case DRA_UnitNumber:                   
@@ -705,11 +705,11 @@ uint Drive::GetDriveAttrs(uint tag, uint attr)
 
 
       case DRA_Drive_ReadSpeeds:             
-          res = d ? (uint)d->GetReadSpeeds() : 0;
+          res = d ? (uintptr_t)d->GetReadSpeeds() : 0;
           break;
 
       case DRA_Drive_WriteSpeeds:
-          res = d ? (uint)d->GetWriteSpeeds() : 0;
+          res = d ? (uintptr_t)d->GetWriteSpeeds() : 0;
           break;
 
       case DRA_Drive_CurrentOperation:       
@@ -721,7 +721,7 @@ uint Drive::GetDriveAttrs(uint tag, uint attr)
           break;
 
       case DRA_Drive_SenseData:
-          res = (uint)driveio->Sense();
+          res = (uintptr_t)driveio->Sense();
           break;
 
       case DRA_Drive_Status:
@@ -741,19 +741,19 @@ uint Drive::GetDriveAttrs(uint tag, uint attr)
           break;
 
       case DRA_Drive_Vendor:                 
-          res = (uint)((inquiry) ? inquiry->VendorID() : "");
+          res = (uintptr_t)((inquiry) ? inquiry->VendorID() : "");
           break;
 
       case DRA_Drive_Product:                
-          res = (uint)((inquiry) ? inquiry->ProductID() : "");
+          res = (uintptr_t)((inquiry) ? inquiry->ProductID() : "");
           break;
 
       case DRA_Drive_Version:                
-          res = (uint)((inquiry) ? inquiry->ProductVersion() : "");
+          res = (uintptr_t)((inquiry) ? inquiry->ProductVersion() : "");
           break;
 
       case DRA_Drive_Firmware:               
-          res = (uint)((inquiry) ? inquiry->FirmwareVersion() : "");
+          res = (uintptr_t)((inquiry) ? inquiry->FirmwareVersion() : "");
           break;
 
       case DRA_Drive_ReadsMedia:             
@@ -818,7 +818,7 @@ uint Drive::GetDriveAttrs(uint tag, uint attr)
           break;
 
       case DRA_Disc_Contents:                
-          res = d ? (uint)d->GetContents() : 0;
+          res = d ? (uintptr_t)d->GetContents() : 0;
           break;
 
       case DRA_Disc_SubType:                 
@@ -870,7 +870,7 @@ uint Drive::GetDriveAttrs(uint tag, uint attr)
           break;
 
       case DRA_Disc_NextWritableTrack:       
-         res = d ? (uint)d->GetNextWritableTrack((IOptItem*)attr) : 0;
+         res = d ? (uintptr_t)d->GetNextWritableTrack((IOptItem*)attr) : 0;
          break;
 
       case DRA_Disc_WriteMethod:             
@@ -882,7 +882,7 @@ uint Drive::GetDriveAttrs(uint tag, uint attr)
          break;
 
       case DRA_Disc_Vendor:                  
-         res = d ? (uint)d->DiscVendor() : 0;
+         res = d ? (uintptr_t)d->DiscVendor() : 0;
          break;
 
       default:
@@ -1042,20 +1042,20 @@ uint32 Drive::ScanDevice(char* sDeviceName)
    _NDS("Device Scan");
    DriveIO    *pIO  = new DriveIO(DEBUG_ENGINE);   // has to be here, called once debug is initialized.
 
-   _D(Lvl_Info, "Checking if device %s is harmless...", (int)sDeviceName);
+   _D(Lvl_Info, "Checking if device %s is harmless...", (uintptr_t)sDeviceName);
    switch (Cfg->Drivers()->isHarmful(sDeviceName))
    {
       case stYes:
          {
             _D(Lvl_Warning, "Device is harmful.");
-            request("Error", "Device %s is considered harmful\nOperation aborted.", "Ok", ARRAY((uint)sDeviceName));
+            request("Error", "Device %s is considered harmful\nOperation aborted.", "Ok", ARRAY((uintptr_t)sDeviceName));
          }
          break;
 
       case stUnknown:
          {
             _D(Lvl_Warning, "Device is not recorded yet.");
-            if (0 == request("Warning", "Device %s is not known and may be harmful.\nDo you want to continue?", "Yes|No", ARRAY((uint)sDeviceName)))
+            if (0 == request("Warning", "Device %s is not known and may be harmful.\nDo you want to continue?", "Yes|No", ARRAY((uintptr_t)sDeviceName)))
             {
                Cfg->Drivers()->addDevice(sDeviceName, true);
                break;

--- a/FryingPan/Optical/Drive.h
+++ b/FryingPan/Optical/Drive.h
@@ -74,7 +74,7 @@ class Drive
    bool                       bLockInterOperations;   // true if we dont want additional operations inbetween our calls
 
    HookT<Drive, Thread*, void*>                 hHkProcMsgs;
-   HookT<Drive, uint, uint*>                  hHkProcHandle;
+   HookT<Drive, uint, uintptr_t*>                  hHkProcHandle;
    
    CfgHardware         *hwconfig;
 
@@ -145,11 +145,11 @@ public:
    CfgHardware         *GetHardwareConfig()
       {  return hwconfig;                    };
 
-   uint                             GetDriveAttrs(uint, uint);
+   uintptr_t                        GetDriveAttrs(uint, uintptr_t);
    uint                             SetDriveAttrs(uint, uint);
 
    uint32                            SetDriveAttrs(TagItem*);
-   uint                             HandleMessages(uint Cmd, uint *Msg);
+   uintptr_t                         HandleMessages(uint Cmd, uintptr_t *Msg);
 
    Page<Page_Write>                &GetWritePage();
    Page<Page_Capabilities>         &GetCapabilitiesPage();

--- a/FryingPan/Optical/Pages.cpp
+++ b/FryingPan/Optical/Pages.cpp
@@ -107,7 +107,7 @@ DRT_Mechanism Page_Capabilities::GetMechanismType()
    }
 }
 
-uint Page_Capabilities::GetCapabilities()
+uintptr_t Page_Capabilities::GetCapabilities()
 {
    unsigned long caps = 0;
    if (rw.doesReadMethod2())              caps |= DRT_Can_Read_Mode2;

--- a/FryingPan/framework/Generic/Debug.cpp
+++ b/FryingPan/framework/Generic/Debug.cpp
@@ -142,11 +142,11 @@ void DbgHandler::InitH()
       DOS->UnLock(DOS->CreateDir(i->Data()));
    }
 
-   j->FormatStr("%s_%05ld.txt", ARRAY((uint)name.Data(), Utility->GetUniqueID()));
+   j->FormatStr("%s_%05ld.txt", ARRAY((uintptr_t)name.Data(), Utility->GetUniqueID()));
    i->AddPath(j->Data());
    DOS->DeleteFile(i->Data());
    fh1 = DOS->Open(i->Data(), MODE_READWRITE);
-   i->FormatStr("con:0/10//80/Debug: %s/auto/close/wait", ARRAY((uint)name.Data()));
+   i->FormatStr("con:0/10//80/Debug: %s/auto/close/wait", ARRAY((uintptr_t)name.Data()));
    if (!silent) fh2 = DOS->Open(i->Data(), MODE_NEWFILE);
    delete i;
    delete j;
@@ -184,8 +184,8 @@ void DbgHandler::PutDate() const
 
    DOS->DateStamp(&CDT.dat_Stamp);
    DOS->DateToStr(&CDT);
-   if (fh2 != 0) DOS->VFPrintf(fh2, "[%s] ", (void*)ARRAY((uint)&TM));
-   if (fh1 != 0) DOS->VFPrintf(fh1, "[%s] ", (void*)ARRAY((uint)&TM));
+   if (fh2 != 0) DOS->VFPrintf(fh2, "[%s] ", (void*)ARRAY((uintptr_t)&TM));
+   if (fh1 != 0) DOS->VFPrintf(fh1, "[%s] ", (void*)ARRAY((uintptr_t)&TM));
 }
 
 void DbgHandler::DoAsync(DbgLevel l, const char* sFmtString, uint vFmtArgs, void* bMemBlock, int lMemLen) const

--- a/FryingPan/framework/Generic/HookT.h
+++ b/FryingPan/framework/Generic/HookT.h
@@ -46,13 +46,13 @@ namespace GenNS
        * \typedef uint (BaseClass::*TCall)(Arg1 a1, Arg2 a2)
        * \brief This specifies a type of the nonvirtual method that can be called by the specialized class when hook fires. You usually should have no interest in this.
        */
-      typedef uint(BaseClass::*TCall)(Arg1 a1, Arg2 a2);
+      typedef uintptr_t(BaseClass::*TCall)(Arg1 a1, Arg2 a2);
 
       /**
        * \typedef uint (*TStaticCall)(Arg1 a1, Arg2 a2)
        * \brief This specifies a type of the static method or function that can be called by the specialized class when hook fires. You usually should have no interest in this.
        */
-      typedef uint(*TStaticCall)(Arg1 a1, Arg2 a2);
+      typedef uintptr_t(*TStaticCall)(Arg1 a1, Arg2 a2);
    
    private:
 
@@ -62,7 +62,7 @@ namespace GenNS
 
    public:
 
-      virtual uint Call(uint a1, uint a2)
+      virtual uintptr_t Call(uintptr_t a1, uintptr_t a2)
       {
          if (0 != baseClass)
          {

--- a/FryingPan/framework/Generic/IHook.h
+++ b/FryingPan/framework/Generic/IHook.h
@@ -79,11 +79,11 @@ namespace GenNS
        * \arg a1 - Object parameter passed to CallHookPkt()
        * \arg a2 - Message parameter passed to CallHookPkt()
        */
-      virtual uint Call(uint a1, uint a2) = 0;
+      virtual uintptr_t Call(uintptr_t a1, uintptr_t a2) = 0;
 
    protected:
 #if defined (__AROS__) || defined (__AMIGAOS4__)
-      static uint subCaller(Hook *pHook, uint pObject, uint pMessage);
+      static uintptr_t subCaller(Hook *pHook, uintptr_t pObject, uintptr_t pMessage);
 #elif defined (__MORPHOS__) || defined(__mc68000)
       static uint subCaller();
 #endif

--- a/FryingPan/framework/Generic/Locale.cpp
+++ b/FryingPan/framework/Generic/Locale.cpp
@@ -66,7 +66,7 @@ void GenNS::Localization::Add(GenNS::Localization::LocaleSet set[], const char* 
    }
 }
 
-const GenNS::String& GenNS::Localization::operator[] (uint val)
+const GenNS::String& GenNS::Localization::operator[] (uintptr_t val)
 {
    return hash.GetVal(val).str;
 }

--- a/FryingPan/framework/Generic/Locale.cpp
+++ b/FryingPan/framework/Generic/Locale.cpp
@@ -78,7 +78,7 @@ bool GenNS::Localization::ReadCatalog(const char* name, sint version)
 
    if (locale != 0)
    {
-      Catalog *cat = locale->OpenCatalogA(0, name, TAGARRAY(OC_Version, static_cast<IPTR>(version), TAG_DONE, 0));
+      Catalog *cat = locale->OpenCatalogA(0, name, ARRAY(OC_Version, static_cast<IPTR>(version), TAG_DONE, 0)); //CODE 2
       if (cat != 0)
       {
          res = true;

--- a/FryingPan/framework/Generic/MUICustomClass.cpp
+++ b/FryingPan/framework/Generic/MUICustomClass.cpp
@@ -32,7 +32,7 @@ void *MUICustomClass::getDispatcher()
    return (void*)&FDispatchCaller;
 }
 
-uint MUICustomClass::dispatch(IClass *cls, Object* obj, IPTR msg)
+IPTR MUICustomClass::dispatch(IClass *cls, Object* obj, IPTR msg)
 {
    GenericBOOPSI       *co;
    GenericBOOPSI      **ptr;

--- a/FryingPan/framework/Generic/NetSocket.cpp
+++ b/FryingPan/framework/Generic/NetSocket.cpp
@@ -32,12 +32,6 @@
 
 using namespace GenNS;
 
-struct timeval
-{
-   uint32      seconds;
-   uint32      micro;
-};
-
    int32          NetSocket::stTrue    = 1;
    int32          NetSocket::stFalse   = 0;
 

--- a/FryingPan/framework/Generic/Set.h
+++ b/FryingPan/framework/Generic/Set.h
@@ -36,18 +36,18 @@ namespace GenNS
     */
    class Set
    {
-      uint                  val;
+      uintptr_t                  val;
    public:
       Set();
-      Set(uint val);
+      Set(uintptr_t val);
       virtual                ~Set();
-      virtual Set&            operator << (uint);
-      virtual Set&            operator >> (uint);
-      virtual Set&            operator =  (uint);
-      virtual bool            operator == (uint);
-      virtual bool            ContainsAny(uint);
-      virtual bool            ContainsAll(uint);
-      virtual                 operator uint ();
+      virtual Set&            operator << (uintptr_t);
+      virtual Set&            operator >> (uintptr_t);
+      virtual Set&            operator =  (uintptr_t);
+      virtual bool            operator == (uintptr_t);
+      virtual bool            ContainsAny(uintptr_t);
+      virtual bool            ContainsAll(uintptr_t);
+      virtual                 operator uintptr_t ();
    };
 };
 #endif

--- a/FryingPan/framework/Generic/Types.h
+++ b/FryingPan/framework/Generic/Types.h
@@ -43,7 +43,9 @@ typedef WORD               int16;   /**< @brief signed 16bit integer */
 typedef BYTE               int8;    /**< @brief signed 8bit integer  */
 
 typedef SIPTR              sint;    /**< @brief architecture specific signed int: sizeof(s_int) = sizeof(void*) */
-typedef IPTR               uint;    /**< @brief architecture specific unsigned int: sizeof(u_int) = sizeof(void*) */
+// Disabled because it conflicts with uint definition in C library
+// FIXME: This probably breaks FP in many places, review usage of uint and replace with uintptr_t
+//typedef IPTR               uint;    /**< @brief architecture specific unsigned int: sizeof(u_int) = sizeof(void*) */
 
 #else
 typedef unsigned long long uint64;  /**< @brief unsigned 64bit integer */

--- a/FryingPan/framework/LibC/StartCode.cpp
+++ b/FryingPan/framework/LibC/StartCode.cpp
@@ -35,8 +35,8 @@
 
    void*                   __InternalMemPool;
    SignalSemaphore         __InternalSemaphore;
-   BPTR                    stdin;
-   BPTR                    stdout;
+   BPTR                    __stdin;
+   BPTR                    __stdout;
    WBStartup              *__WBStartup = 0;
 
    struct Library         *__InternalDOSBase;
@@ -87,8 +87,8 @@ int __setup()
 
    if (0 != __InternalDOSBase)
    {
-      stdin    = Input();
-      stdout   = Output();
+      __stdin    = Input();
+      __stdout   = Output();
    }
 
    // 3. Set up a memory pool. we will need it for our initializations (mem allocs etc)
@@ -226,7 +226,7 @@ void _error(const char* text, ...)
    if (0 != __InternalIntuitionBase)
       EasyRequestArgs(0, (struct EasyStruct*)&es, 0, AROS_SLOWSTACKFORMAT_ARG(text));
    else if (0 != __InternalDOSBase)
-      VFPrintf(stdout, (char*)text, AROS_SLOWSTACKFORMAT_ARG(text));
+      VFPrintf(__stdout, (char*)text, AROS_SLOWSTACKFORMAT_ARG(text));
    AROS_SLOWSTACKFORMAT_POST(text);
 }
 };

--- a/FryingPan/framework/LibC/bzero.c
+++ b/FryingPan/framework/LibC/bzero.c
@@ -21,11 +21,11 @@
 
 void bzero(void* dest, size_t count)
 {
-   uint* v = (uint*)dest;
+   uint32* v = (uint32*)dest;
    uint8* b;
 
-   while ((count & (sizeof(uint)-1)) > 0)
-      *v++ = 0, count -= sizeof(uint);
+   while ((count & (sizeof(uint32)-1)) > 0)
+      *v++ = 0, count -= sizeof(uint32);
 
    b = (uint8*)v;
    while (count > 0)

--- a/FryingPan/framework/libdata/bsdsocket/socket.h
+++ b/FryingPan/framework/libdata/bsdsocket/socket.h
@@ -281,17 +281,4 @@ struct omsghdr
    int32          msg_accrightslen;
 };
 
-/*** Defines and macros for select() *****************************************/
-
-typedef struct fd_set 
-{
-        uint32    fds_bits[2];
-} fd_set;
-
-#define FD_SET(n, p)    ((p)->fds_bits[(n)>>5] |=  (1 << ((n) & 31)))
-#define FD_CLR(n, p)    ((p)->fds_bits[(n)>>5] &= ~(1 << ((n) & 31)))
-#define FD_ISSET(n, p)  ((p)->fds_bits[(n)>>5] &   (1 << ((n) & 31)))
-#define FD_COPY(f, t)   memcpy(t, f, sizeof(*(f)))
-#define FD_ZERO(p)      memset(p, 0, sizeof(*(p)))
-
 #endif /* _DATA_SOCKET_SOCKET_H */

--- a/dopus/Program/doidcmp.c
+++ b/dopus/Program/doidcmp.c
@@ -987,7 +987,7 @@ prevgadgetbank:
                             struct dopusfiletype *type;
                             struct Directory *file;
 
-                            select(win,a - dopus_curwin[win]->offset);
+                            _select(win,a - dopus_curwin[win]->offset);
                             for (file = dopus_curwin[win]->firstentry; a--; file=file->next);
                             strcpy(buf,str_pathbuffer[win]);
                             TackOn(buf,file->name,256);

--- a/dopus/Program/dopusproto.h
+++ b/dopus/Program/dopusproto.h
@@ -43,7 +43,6 @@ int smartcountlines(struct ViewData *);
 int ansicountlines(struct ViewData *);
 void removetabs(struct ViewData *);
 int getusage(void);
-void dprintf (char *,char *,...);
 int filteroff(void);
 void filteron(void);
 
@@ -530,7 +529,7 @@ int getrenamedata(char *,char *);
 
 void doselection(int,int);
 void dormbscroll(int);
-int select(int,int);
+int _select(int,int);
 int unselect(int,struct Directory *);
 void defselect(int,int,int);
 void globalselect(int,int);

--- a/dopus/Program/select.c
+++ b/dopus/Program/select.c
@@ -56,7 +56,7 @@ int win,state;
             else if (offx>drag_sprite.Width*16) offx=drag_sprite.Width*16;
             offy=y-(scrdata_dirwin_ypos[data_active_window]+(a*scrdata_font_ysize));
         }
-        if ((b=select(win,a))==2) {
+        if ((b=_select(win,a))==2) {
             return;
         }
         if (!b || !selectedentry) drag=0;
@@ -339,7 +339,7 @@ int win;
     }
 }
 
-int select(win,o)
+int _select(win,o)
 int win,o;
 {
     int a,dbclick/*=0*/,sel=1,foundcount;

--- a/gnu/gcc/mmakefile.src
+++ b/gnu/gcc/mmakefile.src
@@ -90,7 +90,7 @@ GCC_EXTRA_OPTS += --disable-build-poststage1-with-cxx
 $(TOOLDIR)/% : $(SRCDIR)/$(CURDIR)/target-tool.in
 	@$(ECHO) "Creating cross-compile wrapper for $@"
 	@$(SED) -e 's#@aros_wraptarget_tool@#$(CROSSTOOLSDIR)/$*#g' \
-		-e 's#@aros_wraptarget_args@#$(GCC_ISA_FLAGS)#g' \
+		-e 's#@aros_wraptarget_args@#--sysroot $(AROS_DEVELOPER) $(GCC_ISA_FLAGS)#g' \
 		$< > $@ && chmod 0744 $@
 
 GCC_HOST_VARS += \


### PR DESCRIPTION
Set of change to make FryingPan start and exit without crash on 32-bit AROS when compiled with GCC 6.5.0 and optimizations. These changes have a change of making some things better and 64-bit and some things worse. A general review of usage of type uint is needed to improve 64-bit support further.

Note: first patch is already included in previous PRs and should auto-skip when merging.