### PR TITLE
Don't place output in CROSSTOOLSDIR

### DIFF
--- a/development/libs/icu/mmakefile.src
+++ b/development/libs/icu/mmakefile.src
@@ -38,7 +38,7 @@ ICU_EXTRA_OPTS := \
         --disable-samples \
         --disable-extras \
         --with-data-packaging=static \
-        --with-cross-build=$(CROSSTOOLSDIR)/$(ICU_PKGNAME) \
+        --with-cross-build=$(TOOLDIR)/$(ICU_PKGNAME) \
         --libdir=$(AROS_LIB)
 
 ifneq ($(AROS_TARGET_CPU),i386)

--- a/development/libs/libxml2/mmakefile.src
+++ b/development/libs/libxml2/mmakefile.src
@@ -35,8 +35,8 @@ endif
 
 #MM
 libxml2-post:
-	$(Q)$(IF) ! $(TEST) -f $(CROSSTOOLSDIR)/$(CPU)-aros-xml2-config; then \
-		$(CP) $(AROS_DEV_BINS)/xml2-config $(CROSSTOOLSDIR)/$(CPU)-aros-xml2-config \
+	$(Q)$(IF) ! $(TEST) -f $(TOOLDIR)/$(CPU)-aros-xml2-config; then \
+		$(CP) $(AROS_DEV_BINS)/xml2-config $(TOOLDIR)/$(CPU)-aros-xml2-config \
         && $(SED) -i -e "s|$(AROS_DEVELOPER)|\$${prefix}|g" $(AROS_DEV_BINS)/xml2-config ; \
 	fi
 

--- a/development/libs/libxslt/mmakefile.src
+++ b/development/libs/libxslt/mmakefile.src
@@ -16,7 +16,7 @@ REPOSITORIES := http://xmlsoft.org/sources \
 XSLT_OPTIONS := \
     --without-crypto \
     --without-plugins \
-    --with-libxml-prefix=$(CROSSTOOLSDIR) \
+    --with-libxml-prefix=$(TOOLDIR) \
     --with-libxml-include-prefix=$(AROS_INCLUDES)/libxml2 \
     --without-python \
     --libdir=$(AROS_LIB)


### PR DESCRIPTION
TOOLDIR is specific to build, while CROSSTOOLSDIR can point to a shared, external crosscompiler. Placing output of one build in shared directory confuses other builds and causes them to fail. This PR needs to be merged together with matching PR in AROS repository.