### PR TITLE
Make sure dopusfunction and newdopusfunction have the same layout on 64-bit

### DIFF
--- a/dopus/Library/dopus_stuff.c
+++ b/dopus/Library/dopus_stuff.c
@@ -285,7 +285,9 @@ int __saveds DoReadConfig(register char *name __asm("a0"),register struct Config
             config->menu[a].name=getstringcopy(buf2);
             config->menu[a].pad2[0]=0;
             config->menu[a].pad2[1]=0;
+#if (__WORDSIZE!=64)
             config->menu[a].pad2[2]=0;
+#endif
         }
     }
     if (config->version<=CONFIG_CHANGE_ARROWS)
@@ -507,7 +509,9 @@ int __saveds DoReadConfig(register char *name __asm("a0"),register struct Config
                     bank->gadgets[gad].name=getstringcopy(buf);
                     bank->gadgets[gad].pad2[0]=0;
                     bank->gadgets[gad].pad2[1]=0;
+#if (__WORDSIZE!=64)
                     bank->gadgets[gad].pad2[2]=0;
+#endif
                 }
             }
             if (pos==-1) break;

--- a/dopus/include/dopus/config.h
+++ b/dopus/include/dopus/config.h
@@ -31,6 +31,8 @@ the existing commercial status of Directory Opus 5.
 
 */
 
+#include <aros/cpu.h> // for __WORDSIZE
+
 #define CONFIG_VERSION         10022
 #define CONFIG_MAGIC          0xFACE
 
@@ -166,7 +168,11 @@ struct dopusfunction {
 
 struct newdopusfunction {
     char *name;
+#if (__WORDSIZE==64)
+    int pad2[2];
+#else
     int pad2[3];
+#endif
     int which,stack;
     unsigned char key,qual;
     char type,pri,delay;


### PR DESCRIPTION
These two structures are used  interchangeably in functions; see doidcmp.c and check_key_press.