### PR TITLE
Fixes for demos in Contrib/Demo

### DIFF
--- a/Demo/InfPlane/mmakefile.src
+++ b/Demo/InfPlane/mmakefile.src
@@ -8,11 +8,11 @@ include $(SRCDIR)/config/aros-contrib.cfg
 
 DESTDIR 	:= $(AROS_CONTRIB)/Demos/InfPlane
 
-ifneq (,$(findstring i386,$(AROS_TARGET_CPU)))
-INFPLANE_ASM += refresh-i386
-else
+# The i386 asm (refresh-i386.S) was written for a 16-bit framebuffer
+# (row stride 2*W, 16-bit pixel writes) but the demo uses an 8-bit
+# chunky buffer (W*(H+1) bytes).  That overflows the buffer on 32-bit,
+# so use the correct C function (refresh1) on all architectures.
 USER_CFLAGS += -DC_FUNCTION
-endif
 ifneq (,$(findstring x86_64,$(AROS_TARGET_CPU)))
 OPTIMIZATION_CFLAGS := -O3
 TARGET_ISA_CFLAGS += -msse
@@ -20,7 +20,7 @@ endif
 
 %build_prog mmake=demo-infplane-binary \
     progname=InfPlane targetdir=$(DESTDIR) \
-    files=infplane asmfiles=$(INFPLANE_ASM)
+    files=infplane
 
 DATAFILES	:= pattern.data pattern.pal
 

--- a/Demo/Metaballs/metaballs.c
+++ b/Demo/Metaballs/metaballs.c
@@ -144,10 +144,42 @@ static void Calc_Ball(WORD hohe, WORD breite, APTR po)
 static void Do_Ball(WORD x, WORD y, WORD h, WORD b, APTR po)
 {
     WORD loopy, loopx;
-    UWORD destoffset = (y * W) + x;
     UWORD col;
+    LONG srcoff = 0;
+    WORD bsrc = b;
     UBYTE *src = (UBYTE *)po;
-    
+    UWORD destoffset;
+
+    /* Clip the ball to the visible area of the chunkybuffer.  Without this
+     * the 16-bit destoffset wraps and overflows past the buffer into the
+     * ball[] array and the library base variables when a ball moves off the
+     * bottom/right edge. */
+    if (y >= H || x >= W || y + h <= 0 || x + b <= 0)
+        return;
+
+    if (y < 0)
+    {
+        srcoff += (LONG)(-y) * bsrc;
+        h += y;
+        y = 0;
+    }
+    if (x < 0)
+    {
+        srcoff += -x;
+        b += x;
+        x = 0;
+    }
+    if (h <= 0 || b <= 0)
+        return;
+
+    if (y + h > H)
+        h = H - y;
+    if (x + b > W)
+        b = W - x;
+
+    src += srcoff;
+    destoffset = (UWORD)(y * W + x);
+
     for(loopy = 0; loopy < h; loopy++)
     {
     	for(loopx = 0; loopx < b; loopx++)
@@ -157,6 +189,7 @@ static void Do_Ball(WORD x, WORD y, WORD h, WORD b, APTR po)
 	    if (col > 255) col = 255;
 	    chunkybuffer[destoffset++] = col;
 	}
+	src += (bsrc - b);
 	destoffset += (W - b);
     }
 }
@@ -250,7 +283,7 @@ static void initstuff(void)
     	ball[i - 1].dia = 30 + abs(5 * (j-1));
 	ball[i - 1].rand = (BYTE)(20.0+20.0*sin(i*pi/balls*13));
 	ball[i - 1].p = malloc(SQR(ball[i - 1].dia));
-	if (ball[i].p) cleanup("out of memory!");
+	if (!ball[i - 1].p) cleanup("out of memory!");
 	Calc_Ball(ball[i-1].dia, ball[i-1].dia, ball[i-1].p);
     }
 }

--- a/Demo/RubberStrings/rubberstrings.c
+++ b/Demo/RubberStrings/rubberstrings.c
@@ -252,7 +252,7 @@ static void initstuff(void)
     	ball[i - 1].dia = 2*W;
 	ball[i - 1].rand = (BYTE)(20.0+20.0*sin(i*pi/balls*13));
 	ball[i - 1].p = malloc(SQR(ball[i - 1].dia));
-	if (ball[i].p) cleanup("out of memory!");
+	if (!ball[i - 1].p) cleanup("out of memory!");
 	Calc_Ball(ball[i-1].dia, ball[i-1].dia, ball[i-1].p);
     }
 }


### PR DESCRIPTION
- Fixed a buffer overflow and a false “out of memory!” error in Metaballs
- Fixed an “out of memory!” error in RubberStrings
- Replaced the incorrect i386 assembly code with C functions in InfPlane